### PR TITLE
Allow blurbs on swipe

### DIFF
--- a/public/rawStyles.css
+++ b/public/rawStyles.css
@@ -374,6 +374,8 @@ head-word {
   position: relative;
   text-decoration: none !important;
   white-space: inherit;
+  display: block;
+  width: fit-content;
 }
 
 .dark .headword-link,

--- a/src/functions/jitTippy.js
+++ b/src/functions/jitTippy.js
@@ -1,7 +1,8 @@
 import tippy from "tippy.js";
+import { hideAll } from "tippy.js";
 import getSuttaBlurb from "../functionsBuilding/getSuttaBlurb.js";
 
-const params = { delay: [500, null], touch: ["hold", 500], allowHTML: true, interactive: true };
+const params = { delay: [500, null], touch: ["hold", 500], allowHTML: true, interactive: true, onShow(i){hideAll()} };
 
 document.addEventListener("mouseover", function (event) {
   // Find the closest element that has the 'data-id' attribute
@@ -44,6 +45,5 @@ document.addEventListener("touchstart", function (event) {
     };
 
     element.addEventListener("touchend", cancelTouch, { once: true });
-    element.addEventListener("touchmove", cancelTouch, { once: true });
   }
 });

--- a/src/functions/jitTippy.js
+++ b/src/functions/jitTippy.js
@@ -2,7 +2,10 @@ import tippy from "tippy.js";
 import { hideAll } from "tippy.js";
 import getSuttaBlurb from "../functionsBuilding/getSuttaBlurb.js";
 
-const params = { delay: [500, null], touch: ["hold", 500], allowHTML: true, interactive: true, onShow(i){hideAll()} };
+const MOUSEOVERDELAY = 350;
+const TOUCHDELAY = 250;
+
+const params = { delay: [MOUSEOVERDELAY, null], touch: ["hold", TOUCHDELAY], allowHTML: true, interactive: true, onShow(i){hideAll()} };
 
 document.addEventListener("mouseover", function (event) {
   // Find the closest element that has the 'data-id' attribute
@@ -18,7 +21,7 @@ document.addEventListener("mouseover", function (event) {
       if (element.matches(":hover, :active")) {
         element._tippy.show();
       }
-    }, 500);
+    }, MOUSEOVERDELAY);
   }
 });
 
@@ -37,7 +40,7 @@ document.addEventListener("touchstart", function (event) {
 
     touchTimer = setTimeout(function () {
       element._tippy.show();
-    }, 500);
+    }, TOUCHDELAY);
 
     // Clear the timer if the touch ends or moves
     const cancelTouch = function () {


### PR DESCRIPTION
This doesn't cancel the tip display if the user wiggles their finger on the locator.

Also ensures that only one blurb is open at a time by closing all others before one can open.